### PR TITLE
core_worker: Bump CORE version to 7.4.0

### DIFF
--- a/core_worker/Dockerfile
+++ b/core_worker/Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:20.04
 
-ARG CORE_TAG=release-7.2.1
+ARG CORE_TAG=release-7.4.0
 
 LABEL maintainer="msommer@informatik.uni-marburg.de"
 LABEL name="maciresearch/core_worker"


### PR DESCRIPTION
This PR contains a simple version bump to CORE's latest version for the `core_worker`. I have tested the container in the interactive mode (`DISPLAY`).